### PR TITLE
Fix binding to a specific interface. Closes #23

### DIFF
--- a/ssdpy/cli/server.py
+++ b/ssdpy/cli/server.py
@@ -43,6 +43,11 @@ def parse_args(argv):
         "--location",
         help="Location that notifications should point to. This sets both LOCATION and AL",
     )
+    parser.add_argument(
+        "-a",
+        "--address",
+        help="Address of the interface to listen on. Only valid for IPv4.",
+    )
     return parser.parse_args(argv)
 
 
@@ -63,6 +68,7 @@ def main(argv=None):
         device_type=args.device_type,
         port=args.port,
         iface=args.iface,
+        address=args.address,
         max_age=args.max_age,
         al=args.location,
         location=args.location,

--- a/ssdpy/client.py
+++ b/ssdpy/client.py
@@ -5,6 +5,7 @@ import socket
 from .constants import IPv4, IPv6, ipv4_multicast_ip, ipv6_multicast_ip
 from .http_helper import parse_headers
 from .protocol import create_msearch_payload
+from .compat import if_nametoindex
 
 
 class SSDPClient(object):
@@ -32,6 +33,12 @@ class SSDPClient(object):
         self.sock.settimeout(timeout)
         if iface is not None:
             self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE, iface)
+            if proto is IPv6:
+                # Specifically set multicast on interface
+                iface_index = if_nametoindex(iface)
+                self.sock.setsockopt(
+                    socket.IPPROTO_IPV6, socket.IPV6_MULTICAST_IF, iface_index
+                )
 
     def send(self, data):
         self.sock.sendto(data, self._address)

--- a/ssdpy/compat.py
+++ b/ssdpy/compat.py
@@ -1,6 +1,31 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
+import socket
 import sys
 
 
 PY2 = sys.version_info[0] == 2
+
+string_types = basestring if PY2 else str  # noqa
+
+
+# Python 2 doesn't have socket.if_nametoindex so we need to implement it manually
+if PY2:
+    import ctypes
+    import ctypes.util
+
+    libc = ctypes.CDLL(ctypes.util.find_library('c'))
+
+    def if_nametoindex(name):
+        """
+        Return the logical index number of the given interface name.
+        """
+        if not isinstance(name, string_types):
+            raise TypeError("Expected string type, got '{}'".format(type(name)))
+
+        rc = libc.if_nametoindex(name)
+        if rc == 0:
+            raise RuntimeError("Invalid interface name '{}'".format(name))
+        return rc
+else:
+    if_nametoindex = socket.if_nametoindex


### PR DESCRIPTION

Explicitly subscribe the interface to the multicast address instead of
relying on the OS to decide which interface is valid for multicasts.