### PR TITLE
#60: Use port 1900 for sending unicast NOTIFY request

### DIFF
--- a/ssdpy/server.py
+++ b/ssdpy/server.py
@@ -148,7 +148,7 @@ class SSDPServer(object):
             )
             logger.debug("Created NOTIFY: {}".format(notify))
             try:
-                self.sock.sendto(notify, address)
+                self.sock.sendto(notify, (address[0], 1900))
             except OSError as e:
                 # Most commonly: We received a multicast from an IP not in our subnet
                 logger.debug("Unable to send NOTIFY to {}: {}".format(address, e))


### PR DESCRIPTION
NOTIFY request should be sent to port `1900` instead of to the one taken from `M-SEARCH` request (unicasting)