### PR TITLE
📌 Pin dev dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ pytest-cov==2.10.1
 pytest-mock==3.4.0
 codecov==2.1.11
 sphinx==3.2.0
+Jinja2<3.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
-mock
-pytest
-wheel
-twine
-pytest-cov
-pytest-mock
-codecov
+mock==4.0.3
+pytest==6.2.1
+wheel==0.36.2
+twine==3.3.0
+pytest-cov==2.10.1
+pytest-mock==3.4.0
+codecov==2.1.11
 sphinx==3.2.0


### PR DESCRIPTION
Fixes #66

Also pin Jinja2<3.1 to avoid the issue seen in https://github.com/sphinx-doc/sphinx/issues/10291